### PR TITLE
Add support for disabling autoprefixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ var app = new EmberApp({
 This would prefix styles as required by the two latest version of ios, and disable the cascade (see below).
 The default value for `browsers` are `['> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 12.1']`.
 
+You can disable autoprefixer by passing in `enabled: false`.
+
 Other options, such as [cascade](https://github.com/ai/autoprefixer#visual-cascade) and [sourcemap](https://github.com/sindresorhus/broccoli-autoprefixer#sourcemap) would also go here along with `browsers`.
 
 You can read more about this setting and others [over on the autoprefixer page](https://github.com/ai/autoprefixer#browsers) and/or the [page for broccoli-autoprefixer](https://github.com/sindresorhus/broccoli-autoprefixer#options).

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var path = require('path');
 var fs = require('fs');
 var autoprefixer = require('broccoli-autoprefixer');
+var defaults = require('lodash').defaults;
 
 function EmberCLIAutoprefixer(project) {
   this.project = project;
@@ -10,7 +11,7 @@ function EmberCLIAutoprefixer(project) {
 }
 
 EmberCLIAutoprefixer.prototype.postprocessTree = function (type, tree) {
-  if (type === 'all' || type === 'styles') {
+  if ((type === 'all' || type === 'styles') && this.enabled) {
     tree = autoprefixer(tree, this.options);
   }
 
@@ -19,7 +20,11 @@ EmberCLIAutoprefixer.prototype.postprocessTree = function (type, tree) {
 
 EmberCLIAutoprefixer.prototype.included = function included(app) {
   this.app = app;
-  this.options = this.app.options.autoprefixer;
+  this.options = defaults(this.app.options.autoprefixer || {}, {
+    enabled: true
+  });
+  this.enabled = this.options.enabled;
+  delete this.options.enabled;
 };
 
 EmberCLIAutoprefixer.prototype.treeFor = function treeFor() {};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "author": "Kim Røen",
   "license": "MIT",
   "dependencies": {
-    "broccoli-autoprefixer": "^2.0.0"
+    "broccoli-autoprefixer": "^2.0.0",
+    "lodash": "^3.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #6 

You can now disable autoprefixer by passing in `enabled: false` to its options. Autoprefixer is disabled by default.

For instance to disable in development, you could do something like this:

```js
// Brocfile.js
var app = new EmberApp({
  autoprefixer: {
    enabled: process.env.EMBER_ENV == 'production' ? true : false
  }
});
```