### PR TITLE
Adding support for nesting this addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,11 @@ module.exports = {
   name: 'ember-cli-autoprefixer',
   included: function(app, parentAddon) {
     this.app = app;
+    
+    if (typeof app.import !== 'function' && app.app) {
+      this.app = app = app.app;
+    }
+    
     this._super.included.apply(this, arguments);
     this.options = defaults(this.app.options.autoprefixer || {}, {
       enabled: true


### PR DESCRIPTION
If this addon is used within another addon, an error is thrown about not being able to find the options hash on the app. Please see ember-cli/ember-cli#3718