### PR TITLE
Add support for new targets feature in ember-cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ ember install ember-cli-autoprefixer
 ```
 
 ## Options
-You can configure what browsers to target and other options by specifying them in your
-`ember-cli-build.js` (or `Brocfile.js`). An example:
+By default ember-cli-autoprefixer passes your projects target browsers (in Ember CLI >= 2.13.0)
+to autoprefixer. However, you can manually configure what browsers to target and other options by
+specifying them in your `ember-cli-build.js` (or `Brocfile.js`). An example:
 
 ```js
 var app = new EmberApp(defaults, {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var defaults     = require('lodash/defaults');
 
 module.exports = {
   name: 'ember-cli-autoprefixer',
-  included: function(app, parentAddon) {
+
+  included: function(app) {
     this.app = app;
 
     if (typeof app.import !== 'function' && app.app) {
@@ -14,12 +15,16 @@ module.exports = {
     }
 
     this._super.included.apply(this, arguments);
+
     this.options = defaults(this.app.options.autoprefixer || {}, {
+      browsers: this.project.targets && this.project.targets.browsers,
       enabled: true
     });
+
     this.enabled = this.options.enabled;
     delete this.options.enabled;
   },
+
   postprocessTree: function(type, tree) {
     if ((type === 'all' || type === 'styles') && this.enabled) {
       tree = autoprefixer(tree, this.options);


### PR DESCRIPTION
See:

* https://github.com/ember-cli/rfcs/blob/master/complete/0095-standardise-targets.md
* https://emberjs.com/blog/2017/03/19/ember-2-12-released.html#toc_targets

On older ember-cli versions `project.targets` is undefined, which would cause the default autoprefixer results (same as prior to this change).

On newer ember-cli versions the projects own targets are used and manual configuration in `ember-cli-build.js` is not needed.

Closes #32.