### PR TITLE
Bump autoprefixer to 5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
+  - "6"
+  - "stable"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: node_js
+
 node_js:
   - "4"
   - "6"
@@ -10,6 +11,7 @@ sudo: false
 cache:
   directories:
     - node_modules
+    - bower_components
 
 env:
   - EMBER_TRY_SCENARIO=default

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,9 @@
 {
   "name": "ember-cli-autoprefixer",
   "dependencies": {
-    "ember": "~2.3.1",
-    "ember-cli-shims": "0.1.0",
-    "ember-cli-test-loader": "0.2.2",
+    "ember": "~2.8.1",
+    "ember-cli-shims": "~1.0.0",
+    "ember-cli-test-loader": "~2.1.0",
     "ember-qunit-notifications": "0.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "ember-cli-autoprefixer",
   "dependencies": {
     "ember": "~2.8.1",
-    "ember-cli-shims": "~1.0.0",
     "ember-qunit-notifications": "0.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "ember": "~2.8.1",
     "ember-cli-shims": "~1.0.0",
-    "ember-cli-test-loader": "~2.1.0",
     "ember-qunit-notifications": "0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "preprocess"
   ],
   "dependencies": {
-    "broccoli-autoprefixer": "^4.1.0",
+    "broccoli-autoprefixer": "^5.0.0",
     "lodash": "^4.0.0"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-cli-qunit": "^1.2.1",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.0.0",
+    "ember-cli-test-loader": "~2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "ember-cli": "2.3.0",
+    "ember-cli": "~2.8.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-dependency-checker": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-cli-qunit": "^1.2.1",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.0.0",
+    "ember-cli-shims": "~1.1.0",
     "ember-cli-test-loader": "~2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",


### PR DESCRIPTION
It seems they dropped support for Node 0.12, is this an issue?