### PR TITLE
Bump broccoli-autoprefixer to v5 & drop node .12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - '6'
+  - '4'
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-autoprefixer",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Process styles in an ember-cli application using Autoprefixer",
   "directories": {
     "doc": "doc",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/kimroen/ember-cli-autoprefixer",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4"
   },
   "author": "Kim Røen",
   "license": "MIT",
@@ -53,7 +53,7 @@
     "preprocess"
   ],
   "dependencies": {
-    "broccoli-autoprefixer": "^4.1.0",
+    "broccoli-autoprefixer": "^5.0.0",
     "lodash": "^4.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Duplicate of #36 - I'm not seeing the flickering tests (https://travis-ci.org/kyleshay/ember-cli-autoprefixer/builds - failing test was testing against `node .12`)

Similar to #36: I also updated travis.yml to drop `node 0.12` support per https://github.com/postcss/autoprefixer/commit/6439deda8c6c6ef660d77a434a54272b306e5c24 and https://github.com/sindresorhus/broccoli-autoprefixer/commit/6d060656e8d653e4fae92e009fcd01367816388b

#36 also bumps the ember bower/npm dependencies, but I'm leaving that out of this PR for now.
Tests may be failing in #36 due to something related to https://github.com/ember-cli/ember-cli/pull/5023 should eventually consider bumping ember-cli