### PR TITLE
run autoprefix before asset fingerprinting

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,10 @@
     "lodash": "^4.0.0"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": [
+      "broccoli-asset-rev",
+      "ember-cli-sri"
+    ]
   }
 }


### PR DESCRIPTION
Ember addon dependency to run before broccoli-asset-rev.

Addressing https://github.com/kimroen/ember-cli-autoprefixer/issues/38