### PR TITLE
Update note about using with ember-cli-sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Alternatively, you may use embedded source maps.  So we tell `ember-cli-sass` to
 
 ```js
   sassOptions: {
+    sourceMap: true,
     sourceMapEmbed: true
   },
   autoprefixer: {
@@ -68,6 +69,7 @@ Also note you can optionally disable in production!
   ...
 
   sassOptions: {
+    sourceMap: !envIsProduction,
     sourceMapEmbed: !envIsProduction
   },
   autoprefixer: {


### PR DESCRIPTION
If dart-sass is used (which is the default Sass implementation in ember-cli-sass 9+), `sourceMapEmbed: true` will not work without `sourceMap: true` (if `sourceMap` is not true, the sourcemaps will not be generated regardless of `sourceMapEmbed` or `sourceMapContents`).

https://github.com/sass/dart-sass/blob/3d39f22cbff8097c212dd90a507c22dd808c3f19/lib/src/node.dart#L343-L387