### PR TITLE
Move ember-cli-htmlbars to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "broccoli-autoprefixer": "^9.0.0",
-        "ember-cli-htmlbars": "^5.7.1"
+        "broccoli-autoprefixer": "^9.0.0"
       },
       "devDependencies": {
         "@ember/optional-features": "^2.0.0",
@@ -24,6 +23,7 @@
         "ember-cli": "~3.28.4",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-dependency-checker": "^3.2.0",
+        "ember-cli-htmlbars": "^6.0.0",
         "ember-cli-inject-live-reload": "^2.1.0",
         "ember-cli-sri": "^2.1.1",
         "ember-cli-terser": "^4.0.2",
@@ -1814,6 +1814,7 @@
     },
     "node_modules/@ember/edition-utils": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ember/optional-features": {
@@ -2082,6 +2083,24 @@
         "node": "10.* || 12.* || 14.* || 15.* || >= 16.*"
       }
     },
+    "node_modules/@ember/test-helpers/node_modules/async-disk-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "^2.5.1",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^3.0.0",
+        "rsvp": "^4.8.5",
+        "username-sync": "^1.0.2"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
     "node_modules/@ember/test-helpers/node_modules/broccoli-funnel": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
@@ -2098,6 +2117,46 @@
       },
       "engines": {
         "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@ember/test-helpers/node_modules/broccoli-persistent-filter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
+      "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
+      "dev": true,
+      "dependencies": {
+        "async-disk-cache": "^2.0.0",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^4.0.3",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^3.0.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^2.0.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@ember/test-helpers/node_modules/broccoli-persistent-filter/node_modules/promise-map-series": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
+      "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+      "dev": true,
+      "dependencies": {
+        "rsvp": "^3.0.14"
+      }
+    },
+    "node_modules/@ember/test-helpers/node_modules/broccoli-persistent-filter/node_modules/rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "dev": true,
+      "engines": {
+        "node": "0.12.* || 4.* || 6.* || >= 7.*"
       }
     },
     "node_modules/@ember/test-helpers/node_modules/broccoli-plugin": {
@@ -2135,6 +2194,89 @@
         }
       }
     },
+    "node_modules/@ember/test-helpers/node_modules/editions": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+      "dev": true,
+      "dependencies": {
+        "errlop": "^2.0.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/@ember/test-helpers/node_modules/editions/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@ember/test-helpers/node_modules/ember-cli-htmlbars": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.1.tgz",
+      "integrity": "sha512-9laCgL4tSy48orNoQgQKEHp93MaqAs9ZOl7or5q+8iyGGJHW6sVXIYrVv5/5O9HfV6Ts8/pW1rSoaeKyLUE+oA==",
+      "dev": true,
+      "dependencies": {
+        "@ember/edition-utils": "^1.2.0",
+        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+        "broccoli-debug": "^0.6.5",
+        "broccoli-persistent-filter": "^3.1.2",
+        "broccoli-plugin": "^4.0.3",
+        "common-tags": "^1.8.0",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^5.1.2",
+        "fs-tree-diff": "^2.0.1",
+        "hash-for-dep": "^1.5.1",
+        "heimdalljs-logger": "^0.1.10",
+        "json-stable-stringify": "^1.0.1",
+        "semver": "^7.3.4",
+        "silent-error": "^1.1.1",
+        "strip-bom": "^4.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@ember/test-helpers/node_modules/ember-cli-version-checker": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+      "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+      "dev": true,
+      "dependencies": {
+        "resolve-package-path": "^3.1.0",
+        "semver": "^7.3.4",
+        "silent-error": "^1.1.1"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@ember/test-helpers/node_modules/istextorbinary": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+      "dev": true,
+      "dependencies": {
+        "binaryextensions": "^2.1.2",
+        "editions": "^2.2.0",
+        "textextensions": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
     "node_modules/@ember/test-helpers/node_modules/matcher-collection": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
@@ -2163,6 +2305,19 @@
         "node": "10.* || >= 12.*"
       }
     },
+    "node_modules/@ember/test-helpers/node_modules/resolve-package-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+      "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
     "node_modules/@ember/test-helpers/node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -2176,6 +2331,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@ember/test-helpers/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@ember/test-helpers/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ember/test-helpers/node_modules/sync-disk-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "heimdalljs": "^0.2.6",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^3.0.0",
+        "username-sync": "^1.0.2"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/@ember/test-helpers/node_modules/walk-sync": {
@@ -4312,6 +4507,15 @@
         "babel-template": "^6.24.1"
       }
     },
+    "node_modules/babel-import-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-0.2.0.tgz",
+      "integrity": "sha512-CtWYYHU/MgK88rxMrLfkD356dApswtR/kWZ/c6JifG1m10e7tBBrs/366dFzWMAoqYmG5/JSh+94tUSpIwh+ag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.*"
+      }
+    },
     "node_modules/babel-loader": {
       "version": "8.2.3",
       "dev": true,
@@ -4406,12 +4610,28 @@
     },
     "node_modules/babel-plugin-ember-modules-api-polyfill": {
       "version": "3.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ember-rfc176-data": "^0.3.17"
       },
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/babel-plugin-ember-template-compilation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-1.0.1.tgz",
+      "integrity": "sha512-V/kY6CDyUNrl5Kx6UPKUPhzSKNfdrxNii+S5zK4dgJvVyoxFv7Ykg06Ct/yskY0LkA4wUPdYN7JOBtYJwHk2sg==",
+      "dev": true,
+      "dependencies": {
+        "babel-import-util": "^0.2.0",
+        "line-column": "^1.0.2",
+        "magic-string": "^0.25.7",
+        "string.prototype.matchall": "^4.0.5"
+      },
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/babel-plugin-filter-imports": {
@@ -4429,6 +4649,7 @@
     },
     "node_modules/babel-plugin-htmlbars-inline-precompile": {
       "version": "5.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
@@ -5723,6 +5944,7 @@
     },
     "node_modules/broccoli-debug": {
       "version": "0.6.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-plugin": "^1.2.1",
@@ -5735,6 +5957,7 @@
     },
     "node_modules/broccoli-debug/node_modules/fs-tree-diff": {
       "version": "0.5.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "heimdalljs-logger": "^0.1.7",
@@ -5745,6 +5968,7 @@
     },
     "node_modules/broccoli-debug/node_modules/tree-sync": {
       "version": "1.4.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "debug": "^2.2.0",
@@ -5945,6 +6169,7 @@
     },
     "node_modules/broccoli-plugin": {
       "version": "1.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "promise-map-series": "^0.2.1",
@@ -6554,6 +6779,7 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -7088,6 +7314,7 @@
     },
     "node_modules/common-tags": {
       "version": "1.8.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
@@ -7703,6 +7930,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-keys": "^1.0.12"
@@ -8349,6 +8577,7 @@
     },
     "node_modules/ember-cli-babel-plugin-helpers": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -8466,16 +8695,17 @@
       "license": "ISC"
     },
     "node_modules/ember-cli-htmlbars": {
-      "version": "5.7.1",
-      "license": "MIT",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.0.0.tgz",
+      "integrity": "sha512-7h9Lb1kfvLecMUOX8wCbwjzCsgXdNDs8qpOsDuKV6YaGS9jDZHu4P5xTYLX78YepEUnwOw1atCYWzBUsJHWrzA==",
+      "dev": true,
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+        "babel-plugin-ember-template-compilation": "^1.0.0",
+        "babel-plugin-htmlbars-inline-precompile": "^5.3.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-persistent-filter": "^3.1.2",
         "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
         "ember-cli-version-checker": "^5.1.2",
         "fs-tree-diff": "^2.0.1",
         "hash-for-dep": "^1.5.1",
@@ -8487,11 +8717,12 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/ember-cli-htmlbars/node_modules/async-disk-cache": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
@@ -8508,6 +8739,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/broccoli-persistent-filter": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async-disk-cache": "^2.0.0",
@@ -8528,6 +8760,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/broccoli-plugin": {
       "version": "4.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-node-api": "^1.7.0",
@@ -8544,6 +8777,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/broccoli-plugin/node_modules/promise-map-series": {
       "version": "0.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "10.* || >= 12.*"
@@ -8551,6 +8785,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/debug": {
       "version": "4.3.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -8566,6 +8801,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/editions": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "errlop": "^2.0.0",
@@ -8580,6 +8816,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/editions/node_modules/semver": {
       "version": "6.3.0",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8587,6 +8824,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/ember-cli-version-checker": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-package-path": "^3.1.0",
@@ -8599,6 +8837,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/istextorbinary": {
       "version": "2.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binaryextensions": "^2.1.2",
@@ -8614,6 +8853,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/matcher-collection": {
       "version": "2.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@types/minimatch": "^3.0.3",
@@ -8625,10 +8865,12 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ember-cli-htmlbars/node_modules/resolve-package-path": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-root": "^0.1.1",
@@ -8640,6 +8882,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -8653,6 +8896,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/semver": {
       "version": "7.3.5",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -8666,6 +8910,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/strip-bom": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8673,6 +8918,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/sync-disk-cache": {
       "version": "2.1.0",
+      "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "heimdalljs": "^0.2.6",
@@ -8686,6 +8932,7 @@
     },
     "node_modules/ember-cli-htmlbars/node_modules/walk-sync": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/minimatch": "^3.0.3",
@@ -11088,6 +11335,7 @@
     },
     "node_modules/ember-rfc176-data": {
       "version": "0.3.17",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ember-router-generator": {
@@ -12400,6 +12648,7 @@
     },
     "node_modules/es-abstract": {
       "version": "1.19.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -12438,6 +12687,7 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -14057,6 +14307,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -14085,6 +14336,7 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -14473,6 +14725,7 @@
     },
     "node_modules/has-bigints": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -14496,6 +14749,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -14517,6 +14771,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -15079,6 +15334,7 @@
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.0",
@@ -15144,6 +15400,7 @@
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.1"
@@ -15167,6 +15424,7 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -15186,6 +15444,7 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15225,6 +15484,7 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -15342,6 +15602,7 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15363,6 +15624,7 @@
     },
     "node_modules/is-number-object": {
       "version": "1.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -15425,6 +15687,7 @@
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -15447,6 +15710,7 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15462,6 +15726,7 @@
     },
     "node_modules/is-string": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -15475,6 +15740,7 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -15513,6 +15779,7 @@
     },
     "node_modules/is-weakref": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0"
@@ -15540,6 +15807,7 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isbinaryfile": {
@@ -15734,6 +16002,7 @@
     },
     "node_modules/json-stable-stringify": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jsonify": "~0.0.0"
@@ -15761,6 +16030,7 @@
     },
     "node_modules/jsonify": {
       "version": "0.0.0",
+      "dev": true,
       "license": "Public Domain"
     },
     "node_modules/keyv": {
@@ -15814,6 +16084,7 @@
     },
     "node_modules/line-column": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isarray": "^1.0.0",
@@ -15822,6 +16093,7 @@
     },
     "node_modules/line-column/node_modules/isobject": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isarray": "1.0.0"
@@ -16147,6 +16419,7 @@
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -16157,10 +16430,12 @@
     },
     "node_modules/lru-cache/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/magic-string": {
       "version": "0.25.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sourcemap-codec": "^1.4.4"
@@ -16275,6 +16550,7 @@
     },
     "node_modules/matcher-collection": {
       "version": "1.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minimatch": "^3.0.2"
@@ -17172,6 +17448,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.11.0",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -17179,6 +17456,7 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17197,6 +17475,7 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -17547,6 +17826,7 @@
     },
     "node_modules/parse-static-imports": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/parse5": {
@@ -18639,6 +18919,7 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -19245,6 +19526,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -19262,6 +19544,7 @@
     },
     "node_modules/silent-error": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "debug": "^2.2.0"
@@ -19582,6 +19865,7 @@
     },
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sourcemap-validator": {
@@ -19849,6 +20133,7 @@
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -19883,6 +20168,7 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -19894,6 +20180,7 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -20749,6 +21036,7 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -21140,6 +21428,7 @@
     },
     "node_modules/walk-sync": {
       "version": "0.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ensure-posix-path": "^1.0.0",
@@ -21500,6 +21789,7 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.0.1",
@@ -22999,7 +23289,8 @@
       }
     },
     "@ember/edition-utils": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "dev": true
     },
     "@ember/optional-features": {
       "version": "2.0.0",
@@ -23179,6 +23470,21 @@
         "ember-destroyable-polyfill": "^2.0.3"
       },
       "dependencies": {
+        "async-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.3",
+            "istextorbinary": "^2.5.1",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "rsvp": "^4.8.5",
+            "username-sync": "^1.0.2"
+          }
+        },
         "broccoli-funnel": {
           "version": "3.0.8",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
@@ -23192,6 +23498,42 @@
             "heimdalljs": "^0.2.0",
             "minimatch": "^3.0.0",
             "walk-sync": "^2.0.2"
+          }
+        },
+        "broccoli-persistent-filter": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
+          "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
+          "dev": true,
+          "requires": {
+            "async-disk-cache": "^2.0.0",
+            "async-promise-queue": "^1.0.3",
+            "broccoli-plugin": "^4.0.3",
+            "fs-tree-diff": "^2.0.0",
+            "hash-for-dep": "^1.5.0",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "promise-map-series": "^0.2.1",
+            "rimraf": "^3.0.0",
+            "symlink-or-copy": "^1.0.1",
+            "sync-disk-cache": "^2.0.0"
+          },
+          "dependencies": {
+            "promise-map-series": {
+              "version": "0.2.3",
+              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
+              "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+              "dev": true,
+              "requires": {
+                "rsvp": "^3.0.14"
+              }
+            },
+            "rsvp": {
+              "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+              "dev": true
+            }
           }
         },
         "broccoli-plugin": {
@@ -23218,6 +23560,70 @@
             "ms": "2.1.2"
           }
         },
+        "editions": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^2.0.0",
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "ember-cli-htmlbars": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.1.tgz",
+          "integrity": "sha512-9laCgL4tSy48orNoQgQKEHp93MaqAs9ZOl7or5q+8iyGGJHW6sVXIYrVv5/5O9HfV6Ts8/pW1rSoaeKyLUE+oA==",
+          "dev": true,
+          "requires": {
+            "@ember/edition-utils": "^1.2.0",
+            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+            "broccoli-debug": "^0.6.5",
+            "broccoli-persistent-filter": "^3.1.2",
+            "broccoli-plugin": "^4.0.3",
+            "common-tags": "^1.8.0",
+            "ember-cli-babel-plugin-helpers": "^1.1.1",
+            "ember-cli-version-checker": "^5.1.2",
+            "fs-tree-diff": "^2.0.1",
+            "hash-for-dep": "^1.5.1",
+            "heimdalljs-logger": "^0.1.10",
+            "json-stable-stringify": "^1.0.1",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1",
+            "strip-bom": "^4.0.0",
+            "walk-sync": "^2.2.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+          "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^3.1.0",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1"
+          }
+        },
+        "istextorbinary": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+          "dev": true,
+          "requires": {
+            "binaryextensions": "^2.1.2",
+            "editions": "^2.2.0",
+            "textextensions": "^2.5.0"
+          }
+        },
         "matcher-collection": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
@@ -23240,6 +23646,16 @@
           "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
           "dev": true
         },
+        "resolve-package-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.17.0"
+          }
+        },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -23247,6 +23663,34 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+          "dev": true
+        },
+        "sync-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.6",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "username-sync": "^1.0.2"
           }
         },
         "walk-sync": {
@@ -25028,6 +25472,12 @@
         "babel-template": "^6.24.1"
       }
     },
+    "babel-import-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-0.2.0.tgz",
+      "integrity": "sha512-CtWYYHU/MgK88rxMrLfkD356dApswtR/kWZ/c6JifG1m10e7tBBrs/366dFzWMAoqYmG5/JSh+94tUSpIwh+ag==",
+      "dev": true
+    },
     "babel-loader": {
       "version": "8.2.3",
       "dev": true,
@@ -25092,8 +25542,21 @@
     },
     "babel-plugin-ember-modules-api-polyfill": {
       "version": "3.5.0",
+      "dev": true,
       "requires": {
         "ember-rfc176-data": "^0.3.17"
+      }
+    },
+    "babel-plugin-ember-template-compilation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-1.0.1.tgz",
+      "integrity": "sha512-V/kY6CDyUNrl5Kx6UPKUPhzSKNfdrxNii+S5zK4dgJvVyoxFv7Ykg06Ct/yskY0LkA4wUPdYN7JOBtYJwHk2sg==",
+      "dev": true,
+      "requires": {
+        "babel-import-util": "^0.2.0",
+        "line-column": "^1.0.2",
+        "magic-string": "^0.25.7",
+        "string.prototype.matchall": "^4.0.5"
       }
     },
     "babel-plugin-filter-imports": {
@@ -25108,6 +25571,7 @@
     },
     "babel-plugin-htmlbars-inline-precompile": {
       "version": "5.3.1",
+      "dev": true,
       "requires": {
         "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
         "line-column": "^1.0.2",
@@ -26179,6 +26643,7 @@
     },
     "broccoli-debug": {
       "version": "0.6.5",
+      "dev": true,
       "requires": {
         "broccoli-plugin": "^1.2.1",
         "fs-tree-diff": "^0.5.2",
@@ -26190,6 +26655,7 @@
       "dependencies": {
         "fs-tree-diff": {
           "version": "0.5.9",
+          "dev": true,
           "requires": {
             "heimdalljs-logger": "^0.1.7",
             "object-assign": "^4.1.0",
@@ -26199,6 +26665,7 @@
         },
         "tree-sync": {
           "version": "1.4.0",
+          "dev": true,
           "requires": {
             "debug": "^2.2.0",
             "fs-tree-diff": "^0.5.6",
@@ -26367,6 +26834,7 @@
     },
     "broccoli-plugin": {
       "version": "1.3.1",
+      "dev": true,
       "requires": {
         "promise-map-series": "^0.2.1",
         "quick-temp": "^0.1.3",
@@ -26836,6 +27304,7 @@
     },
     "call-bind": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -27220,7 +27689,8 @@
       "dev": true
     },
     "common-tags": {
-      "version": "1.8.0"
+      "version": "1.8.0",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -27687,6 +28157,7 @@
     },
     "define-properties": {
       "version": "1.1.3",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -28841,7 +29312,8 @@
       }
     },
     "ember-cli-babel-plugin-helpers": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "ember-cli-dependency-checker": {
       "version": "3.2.0",
@@ -28865,15 +29337,17 @@
       "dev": true
     },
     "ember-cli-htmlbars": {
-      "version": "5.7.1",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.0.0.tgz",
+      "integrity": "sha512-7h9Lb1kfvLecMUOX8wCbwjzCsgXdNDs8qpOsDuKV6YaGS9jDZHu4P5xTYLX78YepEUnwOw1atCYWzBUsJHWrzA==",
+      "dev": true,
       "requires": {
         "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+        "babel-plugin-ember-template-compilation": "^1.0.0",
+        "babel-plugin-htmlbars-inline-precompile": "^5.3.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-persistent-filter": "^3.1.2",
         "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
         "ember-cli-version-checker": "^5.1.2",
         "fs-tree-diff": "^2.0.1",
         "hash-for-dep": "^1.5.1",
@@ -28887,6 +29361,7 @@
       "dependencies": {
         "async-disk-cache": {
           "version": "2.1.0",
+          "dev": true,
           "requires": {
             "debug": "^4.1.1",
             "heimdalljs": "^0.2.3",
@@ -28899,6 +29374,7 @@
         },
         "broccoli-persistent-filter": {
           "version": "3.1.2",
+          "dev": true,
           "requires": {
             "async-disk-cache": "^2.0.0",
             "async-promise-queue": "^1.0.3",
@@ -28915,6 +29391,7 @@
         },
         "broccoli-plugin": {
           "version": "4.0.7",
+          "dev": true,
           "requires": {
             "broccoli-node-api": "^1.7.0",
             "broccoli-output-wrapper": "^3.2.5",
@@ -28926,30 +29403,35 @@
           },
           "dependencies": {
             "promise-map-series": {
-              "version": "0.3.0"
+              "version": "0.3.0",
+              "dev": true
             }
           }
         },
         "debug": {
           "version": "4.3.2",
+          "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
         },
         "editions": {
           "version": "2.3.1",
+          "dev": true,
           "requires": {
             "errlop": "^2.0.0",
             "semver": "^6.3.0"
           },
           "dependencies": {
             "semver": {
-              "version": "6.3.0"
+              "version": "6.3.0",
+              "dev": true
             }
           }
         },
         "ember-cli-version-checker": {
           "version": "5.1.2",
+          "dev": true,
           "requires": {
             "resolve-package-path": "^3.1.0",
             "semver": "^7.3.4",
@@ -28958,6 +29440,7 @@
         },
         "istextorbinary": {
           "version": "2.6.0",
+          "dev": true,
           "requires": {
             "binaryextensions": "^2.1.2",
             "editions": "^2.2.0",
@@ -28966,16 +29449,19 @@
         },
         "matcher-collection": {
           "version": "2.0.1",
+          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "minimatch": "^3.0.2"
           }
         },
         "ms": {
-          "version": "2.1.2"
+          "version": "2.1.2",
+          "dev": true
         },
         "resolve-package-path": {
           "version": "3.1.0",
+          "dev": true,
           "requires": {
             "path-root": "^0.1.1",
             "resolve": "^1.17.0"
@@ -28983,21 +29469,25 @@
         },
         "rimraf": {
           "version": "3.0.2",
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "semver": {
           "version": "7.3.5",
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "strip-bom": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         },
         "sync-disk-cache": {
           "version": "2.1.0",
+          "dev": true,
           "requires": {
             "debug": "^4.1.1",
             "heimdalljs": "^0.2.6",
@@ -29008,6 +29498,7 @@
         },
         "walk-sync": {
           "version": "2.2.0",
+          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
@@ -30268,7 +30759,8 @@
       }
     },
     "ember-rfc176-data": {
-      "version": "0.3.17"
+      "version": "0.3.17",
+      "dev": true
     },
     "ember-router-generator": {
       "version": "2.0.0",
@@ -31230,6 +31722,7 @@
     },
     "es-abstract": {
       "version": "1.19.1",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -31261,6 +31754,7 @@
     },
     "es-to-primitive": {
       "version": "1.2.1",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -32402,6 +32896,7 @@
     },
     "get-intrinsic": {
       "version": "1.1.1",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -32418,6 +32913,7 @@
     },
     "get-symbol-description": {
       "version": "1.0.0",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -32686,7 +33182,8 @@
       }
     },
     "has-bigints": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "has-flag": {
       "version": "4.0.0",
@@ -32697,7 +33194,8 @@
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
@@ -32708,6 +33206,7 @@
     },
     "has-tostringtag": {
       "version": "1.0.0",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -33125,6 +33624,7 @@
     },
     "internal-slot": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -33171,6 +33671,7 @@
     },
     "is-bigint": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
@@ -33187,6 +33688,7 @@
     },
     "is-boolean-object": {
       "version": "1.1.2",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -33197,7 +33699,8 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.2.4"
+      "version": "1.2.4",
+      "dev": true
     },
     "is-core-module": {
       "version": "2.8.0",
@@ -33220,6 +33723,7 @@
     },
     "is-date-object": {
       "version": "1.0.5",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -33283,7 +33787,8 @@
       "dev": true
     },
     "is-negative-zero": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "dev": true
     },
     "is-number": {
       "version": "3.0.0",
@@ -33294,6 +33799,7 @@
     },
     "is-number-object": {
       "version": "1.0.6",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -33329,6 +33835,7 @@
     },
     "is-regex": {
       "version": "1.1.4",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -33339,7 +33846,8 @@
       "dev": true
     },
     "is-shared-array-buffer": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -33347,12 +33855,14 @@
     },
     "is-string": {
       "version": "1.0.7",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
     },
     "is-symbol": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -33376,6 +33886,7 @@
     },
     "is-weakref": {
       "version": "1.0.1",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0"
       }
@@ -33391,7 +33902,8 @@
       "dev": true
     },
     "isarray": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "isbinaryfile": {
       "version": "4.0.8",
@@ -33529,6 +34041,7 @@
     },
     "json-stable-stringify": {
       "version": "1.0.1",
+      "dev": true,
       "requires": {
         "jsonify": "~0.0.0"
       }
@@ -33548,7 +34061,8 @@
       }
     },
     "jsonify": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dev": true
     },
     "keyv": {
       "version": "3.0.0",
@@ -33589,6 +34103,7 @@
     },
     "line-column": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "isarray": "^1.0.0",
         "isobject": "^2.0.0"
@@ -33596,6 +34111,7 @@
       "dependencies": {
         "isobject": {
           "version": "2.1.0",
+          "dev": true,
           "requires": {
             "isarray": "1.0.0"
           }
@@ -33861,17 +34377,20 @@
     },
     "lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       },
       "dependencies": {
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         }
       }
     },
     "magic-string": {
       "version": "0.25.7",
+      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -33967,6 +34486,7 @@
     },
     "matcher-collection": {
       "version": "1.1.2",
+      "dev": true,
       "requires": {
         "minimatch": "^3.0.2"
       }
@@ -34654,10 +35174,12 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.11.0"
+      "version": "1.11.0",
+      "dev": true
     },
     "object-keys": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -34668,6 +35190,7 @@
     },
     "object.assign": {
       "version": "4.1.2",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -34904,7 +35427,8 @@
       "dev": true
     },
     "parse-static-imports": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true
     },
     "parse5": {
       "version": "6.0.1",
@@ -35663,6 +36187,7 @@
     },
     "regexp.prototype.flags": {
       "version": "1.3.1",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -36077,6 +36602,7 @@
     },
     "side-channel": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -36089,6 +36615,7 @@
     },
     "silent-error": {
       "version": "1.1.1",
+      "dev": true,
       "requires": {
         "debug": "^2.2.0"
       }
@@ -36321,7 +36848,8 @@
       "dev": true
     },
     "sourcemap-codec": {
-      "version": "1.4.8"
+      "version": "1.4.8",
+      "dev": true
     },
     "sourcemap-validator": {
       "version": "1.1.1",
@@ -36530,6 +37058,7 @@
     },
     "string.prototype.matchall": {
       "version": "4.0.6",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -36554,6 +37083,7 @@
     },
     "string.prototype.trimend": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -36561,6 +37091,7 @@
     },
     "string.prototype.trimstart": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -37173,6 +37704,7 @@
     },
     "unbox-primitive": {
       "version": "1.0.1",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has-bigints": "^1.0.1",
@@ -37466,6 +37998,7 @@
     },
     "walk-sync": {
       "version": "0.3.4",
+      "dev": true,
       "requires": {
         "ensure-posix-path": "^1.0.0",
         "matcher-collection": "^1.0.0"
@@ -37751,6 +38284,7 @@
     },
     "which-boxed-primitive": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "broccoli-autoprefixer": "^9.0.0",
-    "ember-cli-htmlbars": "^5.7.1"
+    "broccoli-autoprefixer": "^9.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -48,6 +47,7 @@
     "ember-cli": "~3.28.4",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-htmlbars": "^6.0.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",


### PR DESCRIPTION
This addon does not ship any templates so there is no need for `ember-cli-htmlbars` in `dependencies` as it's actually used only during tests run.